### PR TITLE
Enable distributed compute workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,34 @@ python clone_client.py --help
 ### Sensitive Data Firewall
 `clone_network.py` now masks API keys and other tokens from shared messages and tasks. Set `FIREWALL_PATTERNS` with comma-separated regexes to customize what gets filtered.
 
-### Excess Compute Sharing
-Run `excess_compute.py` on each clone to contribute idle CPU time back to the cluster. The script checks local CPU usage and only requests tasks from the server when below the `CPU_THRESHOLD` (default 50%). Set `CLONE_SERVER_URL` to the running `clone_network.py` instance and queue tasks via the `/task` endpoint.
+### Distributed Compute Sharing
+You can pool spare CPU cycles from multiple machines using the clone network.
+
+1. **Start the server** on a central node:
+   ```bash
+   python clone_network.py
+   ```
+
+2. **Launch workers** on every machine that should contribute compute power:
+   ```bash
+   export CLONE_SERVER_URL=http://<server-host>:5000
+   python excess_compute.py
+   ```
+   Workers only fetch tasks when their average CPU usage is below the
+   `CPU_THRESHOLD` environment variable (50% by default).
+
+3. **Queue tasks** from any client using the updated `clone_client.py`:
+   ```bash
+   python clone_client.py queue-task "echo hello"
+   ```
+   Results can be viewed with:
+   ```bash
+   python clone_client.py results
+   ```
+
+**Warning:** queued commands are executed with the system shell on each worker.
+Never accept tasks from untrusted sources and avoid running this network on
+machines with sensitive data.
 
 
 ### ChatGPT Integration

--- a/clone_client.py
+++ b/clone_client.py
@@ -48,6 +48,27 @@ def fetch_task():
         print('error:', resp.text)
 
 
+def queue_task(task: str):
+    resp = requests.post(f"{SERVER_URL}/task", json={'task': task})
+    if resp.ok:
+        print('task queued')
+    else:
+        print('error:', resp.text)
+
+
+def read_results():
+    resp = requests.get(f"{SERVER_URL}/updates")
+    if resp.ok:
+        data = resp.json()
+        results = data.get('results', [])
+        if results:
+            print('\n'.join(results))
+        else:
+            print('(no results)')
+    else:
+        print('error:', resp.text)
+
+
 def submit_result(result: str):
     resp = requests.post(f"{SERVER_URL}/task/result", json={'id': CLONE_ID, 'result': result})
     if resp.ok:
@@ -72,6 +93,11 @@ def main():
 
     sub.add_parser('fetch-task', help='request a queued task')
 
+    queue_p = sub.add_parser('queue-task', help='add a task to the queue')
+    queue_p.add_argument('task')
+
+    sub.add_parser('results', help='read completed task results')
+
     result_p = sub.add_parser('submit-result', help='report task result')
     result_p.add_argument('result')
 
@@ -87,6 +113,10 @@ def main():
         get_memories()
     elif args.cmd == 'fetch-task':
         fetch_task()
+    elif args.cmd == 'queue-task':
+        queue_task(args.task)
+    elif args.cmd == 'results':
+        read_results()
     elif args.cmd == 'submit-result':
         submit_result(args.result)
     else:


### PR DESCRIPTION
## Summary
- extend `clone_client.py` with task queue and result retrieval commands
- document how to run a distributed compute cluster using `clone_network.py` and `excess_compute.py`

## Testing
- `python -m py_compile clone_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68897c62dd60832fb3d2552e03c38192