### PR TITLE
Improve autostart watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,13 @@ python hecate.pyz -b       # background
 
 This will start the API server directly from the zip file.
 
+### Self Start on Failure
+Run `autostart.py` to keep the server running even if it crashes. The script
+launches `__main__.py` (or a custom entry defined in `HECATE_ENTRY`) and
+restarts it whenever the process exits with a non‑zero status. Use
+`RESTART_DELAY` to control the delay between restarts and `HECATE_ARGS` to
+provide additional command‑line arguments to the entry script.
+
 ### Self Repair and Improvement
 Use `selfrepair:description` to attempt an automated fix of Hecate's own code based on the issue description. Similarly, `selfimprove:suggestion` asks Hecate to refactor itself with the provided suggestion. Both commands rely on your OpenAI API key and create a `.bak` backup of the current source before overwriting it if successful.
 

--- a/autostart.py
+++ b/autostart.py
@@ -1,0 +1,27 @@
+import os
+import subprocess
+import sys
+import time
+
+SCRIPT = os.getenv("HECATE_ENTRY", "__main__.py")
+ARGS = os.getenv("HECATE_ARGS", "").split()
+DELAY = float(os.getenv("RESTART_DELAY", "5"))
+
+
+def main():
+    while True:
+        try:
+            proc = subprocess.Popen([sys.executable, SCRIPT] + ARGS)
+            ret = proc.wait()
+        except KeyboardInterrupt:
+            proc.terminate()
+            proc.wait()
+            return 1
+        if ret == 0:
+            return 0
+        print(f"Process exited with code {ret}, restarting in {DELAY}s...")
+        time.sleep(DELAY)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- refine `autostart.py` to accept extra args and handle interrupts
- document new `HECATE_ARGS` variable

## Testing
- `python -m py_compile autostart.py`
- `flake8 autostart.py`


------
https://chatgpt.com/codex/tasks/task_e_688c97079324832fbc8d1d0b530b8890