### PR TITLE
Enable server replication

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -44,6 +44,13 @@ class Hecate:
         self.shared_memory_file = "shared_memory.txt"
         self.clone_id = os.getenv("CLONE_ID", os.uname().nodename)
         self.clone_server = os.getenv("CLONE_SERVER_URL")
+        endpoints = os.getenv("CLONE_ENDPOINTS")
+        if endpoints:
+            self.clone_endpoints = [e.strip() for e in endpoints.split(',') if e.strip()]
+        elif self.clone_server:
+            self.clone_endpoints = [self.clone_server]
+        else:
+            self.clone_endpoints = []
         self.last_code = ""
         self.gmail_user = os.getenv("GMAIL_USER")
         self.gmail_pass = os.getenv("GMAIL_PASS")
@@ -174,6 +181,12 @@ class Hecate:
         elif user_input.startswith("selfimprove:"):
             desc = user_input.split("selfimprove:", 1)[1].strip()
             return self._self_improve(desc)
+
+        elif user_input.strip() == "update:deps":
+            return self._update_dependencies()
+
+        elif user_input.strip() == "update:repo":
+            return self._update_repo()
 
         elif user_input.startswith("email:"):
             try:
@@ -533,6 +546,27 @@ class Hecate:
         except Exception as e:
             return f"{self.name}: Failed to improve myself:\n{e}"
 
+    def _update_dependencies(self):
+        """Install or upgrade required Python packages."""
+        try:
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "--upgrade", "-r", "requirements.txt"]
+            )
+            return f"{self.name}: Dependencies updated."
+        except Exception as e:
+            return f"{self.name}: Failed to update dependencies:\n{e}"
+
+    def _update_repo(self):
+        """Pull the latest changes from the git repository."""
+        try:
+            remotes = subprocess.check_output(["git", "remote"]).decode().split()
+            if not remotes:
+                return f"{self.name}: No git remote configured."
+            subprocess.check_call(["git", "pull"])
+            return f"{self.name}: Repository updated."
+        except Exception as e:
+            return f"{self.name}: Failed to update repository:\n{e}"
+
     def _send_email(self, to_addr, subject, body):
         if not (self.gmail_user and self.gmail_pass):
             return f"{self.name}: Gmail credentials not configured."
@@ -575,17 +609,20 @@ class Hecate:
             return f"{self.name}: Failed to fetch emails:\n{e}"
 
     def _clone_send(self, message):
-        if self.clone_server:
+        sent = False
+        for url in list(self.clone_endpoints):
             try:
                 resp = requests.post(
-                    f"{self.clone_server}/send",
+                    f"{url}/send",
                     json={"id": self.clone_id, "message": message},
                     timeout=5,
                 )
                 if resp.ok:
-                    return f"{self.name}: Message broadcast."
+                    sent = True
             except Exception:
-                pass
+                self.clone_endpoints.remove(url)
+        if sent:
+            return f"{self.name}: Message broadcast."
         try:
             with open(self.clone_log_file, "a") as f:
                 f.write(f"{self.clone_id}: {message}\n")
@@ -594,14 +631,18 @@ class Hecate:
             return f"{self.name}: Failed to send message:\n{e}"
 
     def _clone_read(self):
-        if self.clone_server:
+        parts = []
+        for url in list(self.clone_endpoints):
             try:
-                resp = requests.get(f"{self.clone_server}/read", timeout=5)
+                resp = requests.get(f"{url}/read", timeout=5)
                 if resp.ok:
-                    data = resp.text.strip()
-                    return data if data else f"{self.name}: (no messages)"
+                    text = resp.text.strip()
+                    if text:
+                        parts.append(text)
             except Exception:
-                pass
+                self.clone_endpoints.remove(url)
+        if parts:
+            return "\n".join(parts)
         if not os.path.exists(self.clone_log_file):
             return f"{self.name}: No messages."
         with open(self.clone_log_file, "r") as f:
@@ -609,17 +650,20 @@ class Hecate:
         return data if data else f"{self.name}: (no messages)"
 
     def _clone_remember(self, fact):
-        if self.clone_server:
+        stored = False
+        for url in list(self.clone_endpoints):
             try:
                 resp = requests.post(
-                    f"{self.clone_server}/remember",
+                    f"{url}/remember",
                     json={"id": self.clone_id, "fact": fact},
                     timeout=5,
                 )
                 if resp.ok:
-                    return f"{self.name}: Shared memory stored."
+                    stored = True
             except Exception:
-                pass
+                self.clone_endpoints.remove(url)
+        if stored:
+            return f"{self.name}: Shared memory stored."
         try:
             with open(self.shared_memory_file, "a") as f:
                 f.write(f"{self.clone_id}: {fact}\n")
@@ -628,14 +672,18 @@ class Hecate:
             return f"{self.name}: Failed to store memory:\n{e}"
 
     def _clone_memories(self):
-        if self.clone_server:
+        parts = []
+        for url in list(self.clone_endpoints):
             try:
-                resp = requests.get(f"{self.clone_server}/memories", timeout=5)
+                resp = requests.get(f"{url}/memories", timeout=5)
                 if resp.ok:
-                    data = resp.text.strip()
-                    return data if data else f"{self.name}: (no memories)"
+                    text = resp.text.strip()
+                    if text:
+                        parts.append(text)
             except Exception:
-                pass
+                self.clone_endpoints.remove(url)
+        if parts:
+            return "\n".join(parts)
         if not os.path.exists(self.shared_memory_file):
             return f"{self.name}: No shared memories."
         with open(self.shared_memory_file, "r") as f:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use `remember:your fact` to store a memory and `recall` to read them back. The c
 Use `learn:some text` to extract key bullet points from the provided content and append them to memory.
 Use `clone:send:message` to broadcast a message to other running clones. They can read all messages with `clone:read`.
 Use `clone:remember:fact` to store a note in a shared memory file that all clones access. Retrieve the combined notes with `clone:memories`.
-To sync clones over a network, start `clone_network.py` on one machine and set the environment variable `CLONE_SERVER_URL` on each clone to point at that server (e.g. `http://host:5000`). When defined, clone commands will use the server instead of local files. A small helper utility `clone_client.py` provides direct access to these features:
+To sync clones over a network, start `clone_network.py` on one machine and set the environment variable `CLONE_SERVER_URL` or `CLONE_ENDPOINTS` on each clone to point at one or more servers (comma separated). When defined, clone commands will use these endpoints instead of local files and automatically drop any that become unreachable. Servers can optionally replicate with peers listed in `SERVER_ENDPOINTS`. A small helper utility `clone_client.py` provides direct access to these features:
 
 ```bash
 python clone_client.py --help
@@ -43,10 +43,11 @@ You can pool spare CPU cycles from multiple machines using the clone network.
    ```bash
    python clone_network.py
    ```
+   You can provide a comma-separated list of other servers in `SERVER_ENDPOINTS` to enable automatic replication.
 
 2. **Launch workers** on every machine that should contribute compute power:
    ```bash
-   export CLONE_SERVER_URL=http://<server-host>:5000
+   export CLONE_ENDPOINTS=http://<server-host>:5000
    python excess_compute.py
    ```
    Workers only fetch tasks when their average CPU usage is below the

--- a/excess_compute.py
+++ b/excess_compute.py
@@ -4,28 +4,39 @@ import subprocess
 import requests
 import psutil
 
-SERVER_URL = os.getenv('CLONE_SERVER_URL', 'http://localhost:5000')
+def _load_endpoints():
+    env = os.getenv('CLONE_ENDPOINTS')
+    if env:
+        return [u.strip() for u in env.split(',') if u.strip()]
+    url = os.getenv('CLONE_SERVER_URL', 'http://localhost:5000')
+    return [url]
+
+ENDPOINTS = _load_endpoints()
 CLONE_ID = os.getenv('CLONE_ID', os.uname().nodename)
 CPU_THRESHOLD = float(os.getenv('CPU_THRESHOLD', '50'))
 CHECK_INTERVAL = float(os.getenv('CHECK_INTERVAL', '10'))
 
 
 def fetch_task():
-    try:
-        resp = requests.get(f"{SERVER_URL}/task/assign", params={'id': CLONE_ID}, timeout=5)
-        if resp.ok:
-            data = resp.json()
-            return data.get('task')
-    except Exception as e:
-        print(f"error fetching task: {e}")
+    for url in list(ENDPOINTS):
+        try:
+            resp = requests.get(f"{url}/task/assign", params={'id': CLONE_ID}, timeout=5)
+            if resp.ok:
+                data = resp.json()
+                return data.get('task')
+        except Exception as e:
+            print(f"error fetching task from {url}: {e}")
+            ENDPOINTS.remove(url)
     return None
 
 
 def report_result(result):
-    try:
-        requests.post(f"{SERVER_URL}/task/result", json={'id': CLONE_ID, 'result': result}, timeout=5)
-    except Exception as e:
-        print(f"error reporting result: {e}")
+    for url in list(ENDPOINTS):
+        try:
+            requests.post(f"{url}/task/result", json={'id': CLONE_ID, 'result': result}, timeout=5)
+        except Exception as e:
+            print(f"error reporting result to {url}: {e}")
+            ENDPOINTS.remove(url)
 
 
 def main():


### PR DESCRIPTION
## Summary
- allow `clone_network.py` servers to replicate updates from peers
- new `SERVER_ENDPOINTS` and `SERVER_SYNC_INTERVAL` variables
- clones can specify multiple peers via `CLONE_ENDPOINTS`
- document server replication and worker setup in README
- handle unreachable servers more safely
- clean up clone interaction code
- add update commands to workspace Hecate

## Testing
- `python -m py_compile hecate.py 'OK workspaces/hecate.py' clone_client.py clone_network.py excess_compute.py`


------
https://chatgpt.com/codex/tasks/task_e_688c944adc80832f84ece26c69038bb6