### PR TITLE
Add Tailscale and ngrok options for clone network

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ publish its reachable address via `CLONE_PUBLIC_URL` and will periodically
 retrieve the current list of peers from the registry so Hecate hydra heads can
 synchronize without manually specifying every endpoint.
 
+To reach peers behind NAT or firewalls, `clone_network.py` can optionally publish
+its own address automatically. Set `USE_TAILSCALE=1` to advertise the server's
+Tailscale IP or `USE_NGROK=1` to launch an ngrok tunnel. When either option is
+enabled, the script will set `CLONE_PUBLIC_URL` for you. ngrok support requires
+the `pyngrok` package and a valid `NGROK_AUTHTOKEN`.
+
 #### Firebase Memory Storage
 Provide a Firebase service account JSON file and set `FIREBASE_CRED_PATH` to its location to store memories in Firestore. When configured, Hecate mirrors remembered facts in a `memory` collection so they persist across sessions. Without credentials, it falls back to the local `memory.txt` file.
 

--- a/clone_network.py
+++ b/clone_network.py
@@ -49,6 +49,36 @@ CLONE_PUBLIC_URL = os.getenv("CLONE_PUBLIC_URL")
 SYNC_INTERVAL = float(os.getenv("SERVER_SYNC_INTERVAL", "10"))
 
 
+def _setup_public_url():
+    """Populate CLONE_PUBLIC_URL using Tailscale or ngrok if requested."""
+    global CLONE_PUBLIC_URL
+    if CLONE_PUBLIC_URL:
+        return
+    port = os.getenv("CLONE_PORT", "5000")
+    if os.getenv("USE_TAILSCALE"):
+        try:
+            import subprocess
+            ip = subprocess.check_output(["tailscale", "ip", "-4"], text=True).strip()
+            CLONE_PUBLIC_URL = f"http://{ip}:{port}"
+            return
+        except Exception:
+            pass
+    if os.getenv("USE_NGROK"):
+        try:
+            from pyngrok import ngrok
+            token = os.getenv("NGROK_AUTHTOKEN")
+            if token:
+                ngrok.set_auth_token(token)
+            tunnel = ngrok.connect(port, "http")
+            CLONE_PUBLIC_URL = tunnel.public_url
+            return
+        except Exception:
+            pass
+
+
+_setup_public_url()
+
+
 def _discover_endpoints():
     """Register with the central registry and pull the latest peer list."""
     if not REGISTRY_URL:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-flask
-requests
-openai
-flask-cors
 beautifulsoup4
-SpeechRecognition
-psutil
 firebase-admin
+flask
+flask-cors
+openai
+psutil
+pyngrok
+requests
+SpeechRecognition


### PR DESCRIPTION
## Summary
- allow `clone_network.py` to auto-publish public URL via Tailscale or ngrok
- document Tailscale/ngrok usage and add `pyngrok` dependency
- configure ngrok with auth token and ensure HTTP tunnel

## Testing
- `pip install pyngrok`
- `python -m py_compile clone_network.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a0d5abb4832fbda7996faedbaa97