### PR TITLE
Auto-merge support with GitHub API token verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ Colby Atcheson is the server administrator. Update `server_admins.json` to grant
 Use `admin:<password>` to gain admin privileges. Check status with `admin:status` and revoke with `admin:logout`. The default password is `whostheboss` or can be overridden with the `ADMIN_PASSWORD` environment variable.
 
 ### Usage
-1. Create a `config.json` file with your GitHub token and remote URL:
+1. Provide your GitHub token and remote URL using environment variables or a `config.json` file:
+
+   **Environment variables**
+   ```bash
+   export GITHUB_TOKEN=YOUR_GITHUB_TOKEN
+   export GITHUB_REMOTE=https://github.com/username/repo.git
+   ```
+
+   **OR** create a `config.json` file:
    ```json
    {
      "token": "YOUR_GITHUB_TOKEN",
@@ -18,7 +26,21 @@ Use `admin:<password>` to gain admin privileges. Check status with `admin:status
    }
    ```
 2. Run `node hecate-auto.js`
-3. It will pull the latest changes and then commit and push code to your repo automatically
+3. It will pull the latest changes and then commit and push code to your repo automatically. If the pull results in conflicts, the script will stop so you can resolve them manually.
+   To let the script resolve conflicts for you, set `GIT_AUTOMERGE` to `ours` or
+   `theirs` and it will retry the merge using that strategy.
+
+The script verifies your token with the GitHub API before pushing so you know
+your credentials are valid.
+
+### Tests
+Run the unit tests with:
+
+```bash
+npm test
+```
+
+These tests confirm basic functionality such as GitHub API authentication.
 
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
 

--- a/hecate-auto.js
+++ b/hecate-auto.js
@@ -1,32 +1,90 @@
-const { execSync } = require('child_process');
+const child_process = require('child_process');
 const fs = require('fs');
-
-let config;
-try {
-  config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
-} catch (e) {
-  console.error('Missing config.json');
-  process.exit(1);
-}
-
-const { token, remote } = config;
-if (!token || !remote) {
-  console.error('config.json must include "token" and "remote"');
-  process.exit(1);
-}
 
 function run(cmd) {
   console.log('$ ' + cmd);
-  execSync(cmd, { stdio: 'inherit', env: process.env });
+  child_process.execSync(cmd, { stdio: 'inherit', env: process.env });
 }
 
-try {
-  run('git add -A');
-  run('git commit -m "Auto commit by Hecate"');
-} catch (e) {
-  console.log('Nothing to commit');
+function capture(cmd) {
+  return child_process
+    .execSync(cmd, { encoding: 'utf8', env: process.env })
+    .toString();
 }
 
-const url = remote.replace('https://', `https://${token}@`);
-run(`git pull ${url} --rebase`);
-run(`git push ${url}`);
+function verifyToken(token) {
+  try {
+    const output = capture(
+      `curl -s -H "Authorization: Bearer ${token}" https://api.github.com/user`
+    );
+    const data = JSON.parse(output);
+    if (data.login) {
+      console.log(`Authenticated with GitHub API as ${data.login}`);
+    } else {
+      console.warn('GitHub API did not return user information');
+    }
+  } catch (e) {
+    console.warn('GitHub API request failed: ' + e.message);
+  }
+}
+
+function loadCredentials() {
+  let token = process.env.GITHUB_TOKEN;
+  let remote = process.env.GITHUB_REMOTE;
+  if (!token || !remote) {
+    try {
+      const config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
+      token = token || config.token;
+      remote = remote || config.remote;
+    } catch (e) {
+      // ignore missing config file for now
+    }
+  }
+  if (!token || !remote) {
+    console.error(
+      'GitHub token and remote URL must be provided via environment variables or config.json'
+    );
+    process.exit(1);
+  }
+  return { token, remote };
+}
+
+function main() {
+  const { token, remote } = loadCredentials();
+  verifyToken(token);
+  const url = remote.replace(/^https?:\/\//, `https://${token}@`);
+  try {
+    run(`git pull ${url} --rebase`);
+  } catch (e) {
+    const strategy = process.env.GIT_AUTOMERGE;
+    if (strategy === 'ours' || strategy === 'theirs') {
+      console.warn(`Pull failed. Attempting ${strategy} auto-merge.`);
+      try {
+        run('git rebase --abort || true');
+        run(`git fetch ${url}`);
+        const branch = capture('git rev-parse --abbrev-ref HEAD').trim();
+        run(`git merge -X ${strategy} origin/${branch}`);
+      } catch (mergeErr) {
+        console.error('Auto-merge failed. Resolve conflicts manually.');
+        process.exit(1);
+      }
+    } else {
+      console.error('Pull failed. Resolve conflicts and run again.');
+      process.exit(1);
+    }
+  }
+  try {
+    run('git add -A');
+    run('git commit -m "Auto commit by Hecate"');
+  } catch (e) {
+    console.log('Nothing to commit');
+  }
+  run(`git push ${url}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { verifyToken, run, capture, main };
+

--- a/hecate-auto.test.js
+++ b/hecate-auto.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const child_process = require('child_process');
+const { verifyToken } = require('./hecate-auto');
+
+test('verifyToken logs GitHub username on success', (t) => {
+  t.mock.method(child_process, 'execSync', () =>
+    Buffer.from('{"login":"testuser"}')
+  );
+  const messages = [];
+  t.mock.method(console, 'log', (msg) => messages.push(msg));
+  verifyToken('dummy');
+  assert.strictEqual(
+    messages[0],
+    'Authenticated with GitHub API as testuser'
+  );
+});

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.7.2",
     "@fortawesome/fontawesome-svg-core": "6.7.2",


### PR DESCRIPTION
## Summary
- add GitHub API credential verification and optional auto-merge strategy to `hecate-auto.js`
- document auto-merge option, API token verification, and how to run the test suite in the README
- refactor `hecate-auto.js` into reusable functions and add a unit test for token verification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6a080ad84832f804237b411182a5a