### PR TITLE
feat: allow configurable server host and port

### DIFF
--- a/OK workspaces/main.py
+++ b/OK workspaces/main.py
@@ -14,9 +14,9 @@ CORS(app)
 hecate = Hecate()
 
 
-def run_server():
-    """Start the Flask API server."""
-    app.run(host="0.0.0.0", port=8080)
+def run_server(host: str, port: int) -> None:
+    """Start the Flask API server on the given host and port."""
+    app.run(host=host, port=port)
 
 @app.route("/health", methods=["GET"])
 def health():
@@ -61,11 +61,29 @@ if __name__ == "__main__":
         action="store_true",
         help="Run the front end API server in the background",
     )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("HOST", "0.0.0.0"),
+        help="Host interface to bind to",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PORT", "8080")),
+        help="Port to listen on",
+    )
     args = parser.parse_args()
 
     if args.background:
         # Relaunch this script detached from the current session
-        cmd = [sys.executable, os.path.abspath(__file__)]
+        cmd = [
+            sys.executable,
+            os.path.abspath(__file__),
+            "--host",
+            args.host,
+            "--port",
+            str(args.port),
+        ]
         subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
@@ -75,4 +93,4 @@ if __name__ == "__main__":
         )
         print("Server started in background")
     else:
-        run_server()
+        run_server(args.host, args.port)

--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ Both the CLI tools and the API server automatically read the key from these loca
 
    The server logs each conversation to `conversation.log` so you can read back the dialogue later.
 
-   A health check endpoint is available at `http://localhost:8080/health`.
+   A health check endpoint is available at `http://<host>:<port>/health` (default `localhost:8080`).
    Load balancers can poll this URL to verify the service is running.
 
-3. Open `index.html` in your browser. The page will communicate with the server running on `localhost:8080`.
+3. Open `index.html` in your browser. The page will communicate with the server at `http://localhost:8080` by default.
+   Set the `PORT` environment variable or use the `--port` option to run additional instances on different ports on Windows, macOS, or Linux.
 
 ### Command Line Chat
 If you prefer to talk to Hecate directly in your terminal, run the small CLI utility:

--- a/__main__.py
+++ b/__main__.py
@@ -12,13 +12,26 @@ def main():
         action="store_true",
         help="Run the server in the background",
     )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("HOST", "0.0.0.0"),
+        help="Host interface to bind to",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PORT", "8080")),
+        help="Port to listen on",
+    )
     args = parser.parse_args()
 
     current_dir = os.path.dirname(__file__)
     script = os.path.join(current_dir, "OK workspaces", "main.py")
 
+    script_args = ["--host", args.host, "--port", str(args.port)]
+
     if args.background:
-        cmd = [sys.executable, script, "-b"]
+        cmd = [sys.executable, script, "-b"] + script_args
         subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
@@ -28,6 +41,7 @@ def main():
         )
         print("Server started in background")
     else:
+        sys.argv = [script] + script_args
         runpy.run_path(script, run_name="__main__")
 
 if __name__ == "__main__":
@@ -43,4 +57,5 @@ def home():
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))  # 👈 uses Railway's port
-    app.run(host='0.0.0.0', port=port)
+    host = os.environ.get('HOST', '0.0.0.0')
+    app.run(host=host, port=port)

--- a/main.py
+++ b/main.py
@@ -14,9 +14,9 @@ CORS(app)
 hecate = Hecate()
 
 
-def run_server():
-    """Start the Flask API server."""
-    app.run(host="0.0.0.0", port=8080)
+def run_server(host: str, port: int) -> None:
+    """Start the Flask API server on the given host and port."""
+    app.run(host=host, port=port)
 
 @app.route("/health", methods=["GET"])
 def health():
@@ -61,11 +61,29 @@ if __name__ == "__main__":
         action="store_true",
         help="Run the front end API server in the background",
     )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("HOST", "0.0.0.0"),
+        help="Host interface to bind to",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PORT", "8080")),
+        help="Port to listen on",
+    )
     args = parser.parse_args()
 
     if args.background:
         # Relaunch this script detached from the current session
-        cmd = [sys.executable, os.path.abspath(__file__)]
+        cmd = [
+            sys.executable,
+            os.path.abspath(__file__),
+            "--host",
+            args.host,
+            "--port",
+            str(args.port),
+        ]
         subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
@@ -75,4 +93,4 @@ if __name__ == "__main__":
         )
         print("Server started in background")
     else:
-        run_server()
+        run_server(args.host, args.port)


### PR DESCRIPTION
## Summary
- allow Flask API server to bind to custom host and port via flags or environment variables
- forward host and port options through launcher so multiple instances can run simultaneously
- document how to run additional instances on Windows, macOS, or Linux

## Testing
- `python -m py_compile main.py "OK workspaces/main.py" __main__.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6a5bae104832fbcebd50da45cf192