### PR TITLE
Add autostart crash recovery and boot service installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ Both the CLI tools and the API server automatically read the key from these loca
 3. Open `index.html` in your browser. The page will communicate with the server at `http://localhost:8080` by default.
    Set the `PORT` environment variable or use the `--port` option to run additional instances on different ports on Windows, macOS, or Linux.
 
+### Autostart and Crash Recovery
+
+Hecate can install itself as a systemd service so it launches on system boot
+and restarts automatically if it crashes. Run the helper script as root:
+
+```bash
+sudo python install_service.py
+```
+
+The service executes `autostart.py`, which monitors the main process and
+records each crash. After a configurable number of consecutive crashes
+(`MAX_CRASHES`, default `5`), it rolls back the repository to the last known
+good commit to prevent endless restart loops. Use `RESTART_DELAY` to control
+the delay between restart attempts.
+
 ### Command Line Chat
 If you prefer to talk to Hecate directly in your terminal, run the small CLI utility:
 

--- a/autostart.py
+++ b/autostart.py
@@ -6,9 +6,75 @@ import time
 SCRIPT = os.getenv("HECATE_ENTRY", "__main__.py")
 ARGS = os.getenv("HECATE_ARGS", "").split()
 DELAY = float(os.getenv("RESTART_DELAY", "5"))
+MAX_CRASHES = int(os.getenv("MAX_CRASHES", "5"))
+CRASH_FILE = os.getenv("CRASH_FILE", ".hecate_crashes")
+GOOD_FILE = os.getenv("GOOD_COMMIT_FILE", ".hecate_good_commit")
+
+
+def read_int(path, default=0):
+    try:
+        with open(path, "r") as fh:
+            return int(fh.read().strip() or default)
+    except Exception:
+        return default
+
+
+def write_int(path, value):
+    try:
+        with open(path, "w") as fh:
+            fh.write(str(value))
+    except Exception:
+        pass
+
+
+def get_current_commit():
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "HEAD"], text=True)
+            .strip()
+        )
+    except Exception:
+        return ""
+
+
+def write_good_commit(commit):
+    try:
+        with open(GOOD_FILE, "w") as fh:
+            fh.write(commit)
+    except Exception:
+        pass
+
+
+def read_good_commit():
+    try:
+        with open(GOOD_FILE, "r") as fh:
+            return fh.read().strip()
+    except Exception:
+        return ""
+
+
+def rollback():
+    commit = read_good_commit()
+    if not commit:
+        print("No known good commit to roll back to.")
+        return
+    print(f"Rolling back to last known good commit {commit}...")
+    try:
+        subprocess.check_call(["git", "reset", "--hard", commit])
+    except Exception as e:
+        print(f"Rollback failed: {e}")
 
 
 def main():
+    crashes = read_int(CRASH_FILE)
+    if crashes >= MAX_CRASHES:
+        print(
+            f"Detected {crashes} consecutive crashes. Attempting rollback before restarting."
+        )
+        rollback()
+        crashes = 0
+        write_int(CRASH_FILE, crashes)
+
     while True:
         try:
             proc = subprocess.Popen([sys.executable, SCRIPT] + ARGS)
@@ -17,9 +83,27 @@ def main():
             proc.terminate()
             proc.wait()
             return 1
+
         if ret == 0:
+            write_int(CRASH_FILE, 0)
+            good = get_current_commit()
+            if good:
+                write_good_commit(good)
             return 0
-        print(f"Process exited with code {ret}, restarting in {DELAY}s...")
+
+        crashes += 1
+        write_int(CRASH_FILE, crashes)
+        if crashes >= MAX_CRASHES:
+            print(
+                f"Process crashed {crashes} times. Performing rollback to avoid crash loop."
+            )
+            rollback()
+            crashes = 0
+            write_int(CRASH_FILE, crashes)
+
+        print(
+            f"Process exited with code {ret}, restarting in {DELAY}s (crash {crashes}/{MAX_CRASHES})..."
+        )
         time.sleep(DELAY)
 
 

--- a/install_service.py
+++ b/install_service.py
@@ -1,0 +1,64 @@
+"""Helper script to install Hecate as a systemd service.
+
+Running this script writes a small systemd unit file that ensures the
+``autostart.py`` watcher boots with the operating system and restarts if the
+process crashes.  It requires root privileges on Linux systems with systemd.
+
+Usage::
+
+    sudo python install_service.py
+
+After running, the service is enabled and started immediately.  Subsequent
+reboots will automatically launch Hecate via ``autostart.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from textwrap import dedent
+
+
+SERVICE_NAME = "hecate"
+
+
+def main() -> None:
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    python = sys.executable
+    autostart = os.path.join(cwd, "autostart.py")
+
+    service_path = f"/etc/systemd/system/{SERVICE_NAME}.service"
+    service_contents = dedent(
+        f"""
+        [Unit]
+        Description=Hecate self-start service
+        After=network.target
+
+        [Service]
+        Type=simple
+        WorkingDirectory={cwd}
+        ExecStart={python} {autostart}
+        Restart=always
+        RestartSec=5
+
+        [Install]
+        WantedBy=multi-user.target
+        """
+    ).strip()
+
+    try:
+        with open(service_path, "w") as fh:
+            fh.write(service_contents)
+        print(f"Wrote service file to {service_path}")
+        subprocess.run(["systemctl", "daemon-reload"], check=False)
+        subprocess.run(["systemctl", "enable", SERVICE_NAME], check=False)
+        subprocess.run(["systemctl", "start", SERVICE_NAME], check=False)
+        print("Service enabled and started. Hecate will auto-start on boot and restart on crash.")
+    except PermissionError:
+        print("Permission denied. Run this script as root to install the service.")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- track crash counts and roll back to last good commit to avoid restart loops
- add install_service.py for easy systemd setup so Hecate starts on boot
- document autostart and crash recovery options in README

## Testing
- `npm test`
- `python -m py_compile autostart.py install_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a7b7bd70832f98d60d2785394be0