### PR TITLE
feat: capture api endpoints from ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ In the browser interface, type your message into the text box or use the voice b
 You can choose from any system speech synthesis voice using the **Voice** drop-down next to the Speak button.
 You can also click **Summarize Memory** to get a short summary of all remembered facts.
 
+### Adding External APIs
+Use the **API endpoint** field in the interface to submit URLs. Hecate records each entry in `scripts/apis.txt` for later use within its system scripts.
+
 ### API Key Insertion
 Hecate requires an OpenAI API key before it can talk to ChatGPT. You can provide the key in either of the following ways:
 

--- a/hecate.py
+++ b/hecate.py
@@ -490,6 +490,16 @@ class Hecate:
         except Exception as e:
             return f"{self.name}: Failed to create file:\n{e}"
 
+    def add_api(self, api_url):
+        """Record an external API endpoint for future use."""
+        path = os.path.join("scripts", "apis.txt")
+        try:
+            with open(path, "a") as f:
+                f.write(api_url.strip() + "\n")
+            return f"{self.name}: API {api_url} added."
+        except Exception as e:
+            return f"{self.name}: Failed to add API:\n{e}"
+
     def _move_file(self, src, dest):
         src_path = os.path.join("scripts", src)
         dest_path = os.path.join("scripts", dest)

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <div id="output"></div>
     <input type="text" id="userInput" placeholder="Speak your command..."/>
     <button onclick="sendInput()">Submit</button>
+    <input type="text" id="apiInput" placeholder="API endpoint..."/>
+    <button onclick="addApi()">Add API</button>
     <input type="file" id="fileInput" />
   </div>
   <script src="script.js"></script>

--- a/main.py
+++ b/main.py
@@ -53,6 +53,16 @@ def talk_audio():
     response = hecate.respond(text)
     return jsonify({"transcript": text, "reply": response})
 
+
+@app.route("/add_api", methods=["POST"])
+def add_api():
+    data = request.json
+    api_url = data.get("api", "")
+    if not api_url:
+        return jsonify({"status": "missing api"}), 400
+    message = hecate.add_api(api_url)
+    return jsonify({"status": message})
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Hecate API server")
     parser.add_argument(

--- a/script.js
+++ b/script.js
@@ -27,3 +27,23 @@ function generateResponse(input) {
 
   return "No scroll found. Say it again, with intent.";
 }
+
+function addApi() {
+  const api = document.getElementById('apiInput').value.trim();
+  const output = document.getElementById('output');
+  if (!api) return;
+  fetch('/add_api', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ api })
+  })
+    .then(response => response.json())
+    .then(data => {
+      output.innerHTML += `<div><strong>System:</strong> ${data.status}</div>`;
+      output.scrollTop = output.scrollHeight;
+    })
+    .catch(() => {
+      output.innerHTML += `<div><strong>Error:</strong> Failed to add API.</div>`;
+    });
+  document.getElementById('apiInput').value = '';
+}


### PR DESCRIPTION
## Summary
- allow entering API endpoints in the web interface
- add backend route and helper to store submitted API URLs
- document how to add APIs through the interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6a83290bc832fb2d6d6b200068100