### PR TITLE
feat: allow wallpaper customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
     <button onclick="sendInput()">Submit</button>
     <input type="text" id="apiInput" placeholder="API endpoint..."/>
     <button onclick="addApi()">Add API</button>
-    <input type="file" id="fileInput" />
+    <label for="fileInput">Set wallpaper</label>
+    <input type="file" id="fileInput" accept="image/*" />
   </div>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -47,3 +47,20 @@ function addApi() {
     });
   document.getElementById('apiInput').value = '';
 }
+
+document.getElementById('fileInput').addEventListener('change', changeWallpaper);
+
+function changeWallpaper() {
+  const file = this.files[0];
+  if (!file) return;
+  if (!file.type.startsWith('image/')) {
+    alert('Please select an image file.');
+    this.value = '';
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    document.body.style.backgroundImage = `url('${e.target.result}')`;
+  };
+  reader.readAsDataURL(file);
+}

--- a/style.css
+++ b/style.css
@@ -4,6 +4,9 @@ body {
   color: #0ff;
   font-family: monospace;
   background-image: radial-gradient(ellipse at center, #000 0%, #111 100%);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   overflow: hidden;
 }
 #container {


### PR DESCRIPTION
## Summary
- enable selecting an image to set as the interface background
- style body to properly display wallpaper images
- add file input label and image-only restriction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6aabf4c98832fb7481df27d24cad5