### PR TITLE
Fix background server execution and add home endpoint

### DIFF
--- a/OK workspaces/main.py
+++ b/OK workspaces/main.py
@@ -14,6 +14,11 @@ CORS(app)
 hecate = Hecate()
 
 
+@app.route("/")
+def home():
+    return jsonify({"message": "MandemOS Hecate online."})
+
+
 def run_server(host: str, port: int) -> None:
     """Start the Flask API server on the given host and port."""
     app.run(host=host, port=port)

--- a/__main__.py
+++ b/__main__.py
@@ -26,12 +26,12 @@ def main():
     args = parser.parse_args()
 
     current_dir = os.path.dirname(__file__)
-    script = os.path.join(current_dir, "OK workspaces", "main.py")
+    script = os.path.join(current_dir, "main.py")
 
     script_args = ["--host", args.host, "--port", str(args.port)]
 
     if args.background:
-        cmd = [sys.executable, script, "-b"] + script_args
+        cmd = [sys.executable, script] + script_args
         subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
@@ -43,19 +43,6 @@ def main():
     else:
         sys.argv = [script] + script_args
         runpy.run_path(script, run_name="__main__")
-
+    
 if __name__ == "__main__":
     main()
-import os
-from flask import Flask
-
-app = Flask(__name__)
-
-@app.route('/')
-def home():
-    return 'MandemOS Hecate online.'
-
-if __name__ == '__main__':
-    port = int(os.environ.get('PORT', 5000))  # 👈 uses Railway's port
-    host = os.environ.get('HOST', '0.0.0.0')
-    app.run(host=host, port=port)

--- a/main.py
+++ b/main.py
@@ -14,6 +14,11 @@ CORS(app)
 hecate = Hecate()
 
 
+@app.route("/")
+def home():
+    return jsonify({"message": "MandemOS Hecate online."})
+
+
 def run_server(host: str, port: int) -> None:
     """Start the Flask API server on the given host and port."""
     app.run(host=host, port=port)


### PR DESCRIPTION
## Summary
- remove redundant Flask app in `__main__.py` so background mode does not block terminal
- add simple `/` route to server modules to report "MandemOS Hecate online."
- avoid double-spawning background process by not passing `-b` when launching server via `__main__.py`
- return JSON from the home endpoint for consistency with other API routes
- reference the top-level `main.py` in `__main__.py` to avoid path conflicts

## Testing
- `python -m py_compile __main__.py main.py 'OK workspaces/main.py'`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6a934545c832fac67a2ae48674917