### PR TITLE
Serve static HTML

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,14 @@ import sys
 import os
 import speech_recognition as sr
 
-app = Flask(__name__)
+# Serve static files (e.g., index.html) from the repository root so the
+# Flask server can act as a lightweight static site host.
+app = Flask(__name__, static_folder=".", static_url_path="")
+@app.route("/")
+def root():
+    """Serve the main interface."""
+    return app.send_static_file("index.html")
+
 CORS(app)
 
 # Instantiate Hecate


### PR DESCRIPTION
## Summary
- configure Flask to serve repository root as static folder
- add root route so `index.html` loads when hitting the server

## Testing
- `python -m py_compile main.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6ae4a5bbc832f967e1d747c25b8cc