### PR TITLE
Add personalization settings to web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 > The daemon who codes, commits, and controls the flame of your GitHub repo.
 
+### Personalization
+
+Open the web interface and click **Settings** to customize your experience. You can set a username, choose text and background colors, and pick a wallpaper. Preferences are saved in your browser.
+
 ### Server Administration
 Colby Atcheson is the server administrator. Update `server_admins.json` to grant additional admin access.
 

--- a/index.html
+++ b/index.html
@@ -14,8 +14,14 @@
     <button onclick="sendInput()">Submit</button>
     <input type="text" id="apiInput" placeholder="API endpoint..."/>
     <button onclick="addApi()">Add API</button>
-    <label for="fileInput">Set wallpaper</label>
-    <input type="file" id="fileInput" accept="image/*" />
+    <button id="settingsBtn">Settings</button>
+    <div id="settingsPanel" style="display:none;">
+      <label>Username <input type="text" id="usernameInput" /></label>
+      <label>Text color <input type="color" id="textColorInput" /></label>
+      <label>Background color <input type="color" id="bgColorInput" /></label>
+      <label>Wallpaper <input type="file" id="fileInput" accept="image/*" /></label>
+      <button onclick="saveSettings()">Save</button>
+    </div>
   </div>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
 
+let userName = 'You';
+
 function sendInput() {
   const inputField = document.getElementById('userInput');
   const input = inputField.value.trim();
@@ -6,7 +8,7 @@ function sendInput() {
   if (!input) return;
   inputField.value = '';
 
-  output.innerHTML += `<div><strong>You:</strong> ${input}</div>`;
+  output.innerHTML += `<div><strong>${userName}:</strong> ${input}</div>`;
   output.innerHTML += `<div><strong>Glitchborne:</strong> <span class="glitch">🧠 processing...</span></div>`;
 
   setTimeout(() => {
@@ -50,7 +52,40 @@ function addApi() {
   document.getElementById('apiInput').value = '';
 }
 
+document.getElementById('settingsBtn').addEventListener('click', toggleSettings);
 document.getElementById('fileInput').addEventListener('change', changeWallpaper);
+applySettings();
+
+function toggleSettings() {
+  const panel = document.getElementById('settingsPanel');
+  panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+}
+
+function saveSettings() {
+  const username = document.getElementById('usernameInput').value.trim() || 'You';
+  const textColor = document.getElementById('textColorInput').value;
+  const bgColor = document.getElementById('bgColorInput').value;
+  localStorage.setItem('username', username);
+  localStorage.setItem('textColor', textColor);
+  localStorage.setItem('bgColor', bgColor);
+  applySettings();
+  toggleSettings();
+}
+
+function applySettings() {
+  userName = localStorage.getItem('username') || 'You';
+  const textColor = localStorage.getItem('textColor') || '#0ff';
+  const bgColor = localStorage.getItem('bgColor') || '#000000';
+  document.documentElement.style.setProperty('--text-color', textColor);
+  document.documentElement.style.setProperty('--bg-color', bgColor);
+  const wallpaper = localStorage.getItem('wallpaper');
+  if (wallpaper) {
+    document.body.style.backgroundImage = `url('${wallpaper}')`;
+  }
+  document.getElementById('usernameInput').value = userName;
+  document.getElementById('textColorInput').value = textColor;
+  document.getElementById('bgColorInput').value = bgColor;
+}
 
 function changeWallpaper() {
   const file = this.files[0];
@@ -62,7 +97,9 @@ function changeWallpaper() {
   }
   const reader = new FileReader();
   reader.onload = (e) => {
-    document.body.style.backgroundImage = `url('${e.target.result}')`;
+    const dataUrl = e.target.result;
+    document.body.style.backgroundImage = `url('${dataUrl}')`;
+    localStorage.setItem('wallpaper', dataUrl);
   };
   reader.readAsDataURL(file);
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,11 @@
+:root {
+  --text-color: #0ff;
+  --bg-color: black;
+}
 
 body {
-  background-color: black;
-  color: #0ff;
+  background-color: var(--bg-color);
+  color: var(--text-color);
   font-family: monospace;
   background-image: radial-gradient(ellipse at center, #000 0%, #111 100%);
   background-size: cover;
@@ -13,22 +17,34 @@ body {
   max-width: 600px;
   margin: 100px auto;
   padding: 20px;
-  border: 1px solid #0ff;
+  border: 1px solid var(--text-color);
   background: rgba(0, 0, 0, 0.9);
 }
 input, button {
   display: block;
   margin-top: 10px;
   width: 100%;
-  background: black;
-  color: #0ff;
-  border: 1px solid #0ff;
+  background: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--text-color);
   padding: 8px;
 }
 #output {
   padding: 10px;
   margin-bottom: 10px;
-  border: 1px dashed #0ff;
+  border: 1px dashed var(--text-color);
   min-height: 100px;
   background-color: rgba(0,0,0,0.5);
+}
+
+#settingsPanel {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px dashed var(--text-color);
+  background: rgba(0,0,0,0.8);
+}
+
+#settingsPanel label {
+  display: block;
+  margin-top: 5px;
 }


### PR DESCRIPTION
## Summary
- Add Settings panel to customize username, colors, and wallpaper with persistence via localStorage
- Apply theme colors using CSS variables and update README with personalization instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6af5dec1c832f95c871be1c9d0535