### PR TITLE
feat: add basic agent manager

### DIFF
--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1,0 +1,40 @@
+import json
+import os
+from typing import List, Dict
+
+class AgentManager:
+    """Simple manager for storing lightweight agent descriptions.
+
+    Agents are persisted to a JSON file so they survive restarts. Each
+    agent has a ``name`` and ``description``. This class provides
+    minimal functionality required by the user request.
+    """
+
+    def __init__(self, path: str = "agents.json") -> None:
+        self.path = path
+        self._agents: List[Dict[str, str]] = []
+        self._load()
+
+    def _load(self) -> None:
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, "r", encoding="utf-8") as f:
+                    self._agents = json.load(f)
+            except Exception:
+                self._agents = []
+        else:
+            self._agents = []
+
+    def _save(self) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self._agents, f, indent=2)
+
+    # Public API -------------------------------------------------------------
+    def add_agent(self, name: str, description: str) -> None:
+        """Add a new agent description and persist it."""
+        self._agents.append({"name": name, "description": description})
+        self._save()
+
+    def list_agents(self) -> List[Dict[str, str]]:
+        """Return the list of known agents."""
+        return list(self._agents)

--- a/hecate.py
+++ b/hecate.py
@@ -9,6 +9,7 @@ import email
 from email.mime.text import MIMEText
 import openai
 import subprocess
+from agent_manager import AgentManager
 from self_improvement_lattice import SelfImprovementLattice
 try:
     import firebase_admin
@@ -79,6 +80,7 @@ class Hecate:
         self.admin_file = "admin_status.txt"
         self._load_admin_status()
         self.lattice = SelfImprovementLattice()
+        self.agent_manager = AgentManager()
         # store recent conversation turns for context-aware replies
         self.conversation = []
         # optional Firebase database for memory retention
@@ -207,6 +209,21 @@ class Hecate:
 
         elif user_input.strip() == "update:repo":
             return self._update_repo()
+
+        elif user_input.startswith("agent:add:"):
+            try:
+                name, desc = user_input.split("agent:add:", 1)[1].split("|", 1)
+                self.agent_manager.add_agent(name.strip(), desc.strip())
+                return f"{self.name}: Agent '{name.strip()}' added."
+            except ValueError:
+                return f"{self.name}: Use 'agent:add:name|description'"
+
+        elif user_input.strip() == "agent:list":
+            agents = self.agent_manager.list_agents()
+            if not agents:
+                return f"{self.name}: No agents registered."
+            lines = [f"{a['name']}: {a['description']}" for a in agents]
+            return f"{self.name}: Registered agents:\n" + "\n".join(lines)
 
         elif user_input.startswith("email:"):
             try:


### PR DESCRIPTION
## Summary
- add `AgentManager` to persist simple agent descriptions
- wire Hecate to add and list agents via new commands

## Testing
- `python -m py_compile agent_manager.py hecate.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6afa0db9c832fa25a0401085c28d7