### PR TITLE
chore: add hugo build script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,17 +8,11 @@
 ## an existing lockfile.
 
 [build]
-  # For this project there is no compile step – it's a plain HTML/JS site.
-  # We still run `npm install` so that Netlify will generate a lockfile
-  # (required by `npm ci` if you later enable that) and to satisfy the
-  # build command requirement. The build script defined in package.json
-  # simply echoes a message and does nothing else.
+  # Install npm dependencies and run the Hugo build script.
   command = "npm install --no-audit --no-fund && npm run build"
 
-  # The site files (index.html, script.js, style.css) live in the root
-  # of the repository. Set the publish directory to "." so Netlify
-  # serves these files directly.
-  publish = "."
+  # Hugo outputs the generated site to the "public" directory.
+  publish = "public"
 
 [build.environment]
   # Pin the Node.js version to match Netlify's default LTS version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "http-server .",
-    "build": "echo \"No build step\"",
+    "build": "hugo",
     "test": "node --test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add Hugo build command to npm scripts
- configure Netlify to publish the Hugo `public` directory

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: hugo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6af80da98832f882dc226ca74025b