### PR TITLE
Fix background server execution and add home endpoint

### DIFF
--- a/OK workspaces/main.py
+++ b/OK workspaces/main.py
@@ -7,11 +7,19 @@ import sys
 import os
 import speech_recognition as sr
 
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
 app = Flask(__name__)
 CORS(app)
 
 # Instantiate Hecate
 hecate = Hecate()
+
+
+@app.route("/")
+def home():
+    """Simple status endpoint to confirm the server is running."""
+    return jsonify({"message": "MandemOS Hecate online."})
 
 
 def run_server(host: str, port: int) -> None:
@@ -74,6 +82,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    os.chdir(script_dir)
+
     if args.background:
         # Relaunch this script detached from the current session
         cmd = [
@@ -86,6 +96,7 @@ if __name__ == "__main__":
         ]
         subprocess.Popen(
             cmd,
+            cwd=script_dir,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,

--- a/__main__.py
+++ b/__main__.py
@@ -25,15 +25,17 @@ def main():
     )
     args = parser.parse_args()
 
-    current_dir = os.path.dirname(__file__)
-    script = os.path.join(current_dir, "OK workspaces", "main.py")
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(current_dir)
+    script = os.path.join(current_dir, "main.py")
 
     script_args = ["--host", args.host, "--port", str(args.port)]
 
     if args.background:
-        cmd = [sys.executable, script, "-b"] + script_args
+        cmd = [sys.executable, script] + script_args
         subprocess.Popen(
             cmd,
+            cwd=current_dir,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
@@ -43,19 +45,6 @@ def main():
     else:
         sys.argv = [script] + script_args
         runpy.run_path(script, run_name="__main__")
-
+    
 if __name__ == "__main__":
     main()
-import os
-from flask import Flask
-
-app = Flask(__name__)
-
-@app.route('/')
-def home():
-    return 'MandemOS Hecate online.'
-
-if __name__ == '__main__':
-    port = int(os.environ.get('PORT', 5000))  # 👈 uses Railway's port
-    host = os.environ.get('HOST', '0.0.0.0')
-    app.run(host=host, port=port)

--- a/main.py
+++ b/main.py
@@ -7,11 +7,19 @@ import sys
 import os
 import speech_recognition as sr
 
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
 app = Flask(__name__)
 CORS(app)
 
 # Instantiate Hecate
 hecate = Hecate()
+
+
+@app.route("/")
+def home():
+    """Simple status endpoint to confirm the server is running."""
+    return jsonify({"message": "MandemOS Hecate online."})
 
 
 def run_server(host: str, port: int) -> None:
@@ -74,6 +82,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
+    os.chdir(script_dir)
+
     if args.background:
         # Relaunch this script detached from the current session
         cmd = [
@@ -86,6 +96,7 @@ if __name__ == "__main__":
         ]
         subprocess.Popen(
             cmd,
+            cwd=script_dir,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
- remove redundant Flask app in `__main__.py` so background mode does not block terminal
- add simple `/` route to server modules to report "MandemOS Hecate online."
- avoid double-spawning background process by not passing `-b` when launching server via `__main__.py`
- return JSON from the home endpoint for consistency with other API routes
- reference the top-level `main.py` in `__main__.py` to avoid path conflicts
- document the home endpoint with a brief status docstring
- ensure background processes run from the correct directory to avoid path conflicts
- change entrypoint and server modules to switch to their own directories before launching to keep relative paths consistent

## Testing
- `python -m py_compile __main__.py main.py 'OK workspaces/main.py'`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6a934545c832fac67a2ae48674917